### PR TITLE
Created  basic layout structure for main page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,13 +1,10 @@
 import './App.css';
+import MainLayout from './MainLayout'
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <h1 className="text-3xl font-bold underline">
-          Hello world!
-        </h1>
-      </header>
+      <MainLayout/>   
     </div>
   );
 }

--- a/client/src/MainLayout.css
+++ b/client/src/MainLayout.css
@@ -1,0 +1,42 @@
+.main-layout {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+}
+
+.layout-header {
+    background-color: #1b1e21;
+    color: white;
+    padding: 25px;
+    text-align: center;
+}
+
+.chat-sec {
+    background-color: #d1d5db;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.user-input-field {
+    flex: 1;
+    border: 1px solid #d1d5db;
+    border-radius: 0.5rem;
+    padding: 0.5rem;
+    margin-right: 0.5rem;
+}
+
+.input-sec {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 4px;
+}
+
+.send-button {
+    background-color: #3b82f6;
+    color: white;
+    padding: 0.5rem 1rem;
+
+}

--- a/client/src/MainLayout.tsx
+++ b/client/src/MainLayout.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import './MainLayout.css';
+
+const MainLayout: React.FC = () => {
+    return (
+        <div className="main-layout">
+            <header className="layout-header">
+                <h1>cat-GPT</h1>
+            </header>
+            <main className='chat-sec'>
+                <div>
+                    {/* Chat Area Placeholder */}
+                    <span>CHAT AREA</span>
+
+                </div>
+            </main>
+
+            <footer className='footer-sec'>
+                <div className='input-sec'>
+                    {/* User Input Placeholder */}
+                    <input
+                        type="text"
+                        className='user-input-field'
+                        placeholder='USER INPUT SECTION '
+                    />
+                    <button className='send-button'>REQUEST</button>
+                </div>
+            </footer>
+        </div>
+    );
+};
+
+export default MainLayout;

--- a/client/src/MainLayout.tsx
+++ b/client/src/MainLayout.tsx
@@ -1,33 +1,33 @@
 import React from 'react';
-import './MainLayout.css';
+
 
 const MainLayout: React.FC = () => {
     return (
-        <div className="main-layout">
-            <header className="layout-header">
-                <h1>cat-GPT</h1>
+        <div className="flex flex-col h-screen">
+            <header className="bg-blue-500 text-black p-5 text-center">
+                <h1 className="text-3xl font-bold">Cat-GPT</h1>
             </header>
-            <main className='chat-sec'>
-                <div>
-                    {/* Chat Area Placeholder */}
-                    <span>CHAT AREA</span>
-
+            <main className="flex-1 bg-blue-100 p-4 overflow-auto">
+                {/* Chat Area Placeholder */}
+                <div className="h-full flex flex-col items-center justify-center">
+                    <span className="text-black-500 mb-4">CHAT AREA</span>
+                    <img src="https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif" alt="Cat GIF" className="max-w-full max-h-full object-contain" />
                 </div>
             </main>
-
-            <footer className='footer-sec'>
-                <div className='input-sec'>
-                    {/* User Input Placeholder */}
-                    <input
-                        type="text"
-                        className='user-input-field'
-                        placeholder='USER INPUT SECTION '
-                    />
-                    <button className='send-button'>REQUEST</button>
-                </div>
+            <footer className="bg-white p-4 flex items-center">
+                {/* User Input Placeholder */}
+                <input
+                    type="text"
+                    className="flex-1 border border-gray-300 p-2 mr-2"
+                    placeholder="USER INPUT SECTION"
+                />
+                <button className="bg-green-500 text-black p-2">
+                    REQUEST
+                </button>
             </footer>
         </div>
     );
 };
 
 export default MainLayout;
+


### PR DESCRIPTION
This PR introduces a basic layout structure for the main page of the CatGPT application.

Changes include:
- Created a new `MainLayout` component with placeholders for the chat area and user input section  .
- Separated CSS into `MainLayout.css` for better maintainability.
- Updated `App.tsx` to integrate `MainLayout`.
![catGPT](https://github.com/Sweetdevil144/Cat-GPT/assets/146512765/229c4a84-c581-4ea7-a20f-023c62ac610d)

